### PR TITLE
Remove faulty Listing properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ API. For more details read the [Reddit OAuth2 wiki](https://github.com/reddit-ar
 5. Select "create app"
 
 Once your application is created you will need to copy the "client ID" and "secret" (see the
-wiki article above fo help). Add these along with your username and password into your
+wiki article above for help). Add these along with your username and password into your
 project's **.env** file, for example:
 ```
 #--------------------------------------------------------------------

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -14,6 +14,7 @@ parameters:
 	universalObjectCratesClasses:
 		- CodeIgniter\Entity
 		- Faker\Generator
+		- Tatter\Reddit\Structures\Thing
 	scanDirectories:
 		- vendor/codeigniter4/codeigniter4/system/Helpers
 	dynamicConstantNames:

--- a/src/Structures/Listing.php
+++ b/src/Structures/Listing.php
@@ -13,22 +13,6 @@ use Tatter\Reddit\Exceptions\RedditException;
 class Listing extends Thing implements Iterator
 {
 	/**
-	 * Fullname of the listing that follows after this page.
-	 * `null` if there is no next page.
-	 *
-	 * @var string|null
-	 */
-	public $after;
-
-	/**
-	 * Fullname of the listing that follows before this page.
-	 * `null` if there is no previous page.
-	 *
-	 * @var string|null
-	 */
-	public $before;
-
-	/**
 	 * Children from API result.
 	 *
 	 * @var array

--- a/tests/structures/ListingTest.php
+++ b/tests/structures/ListingTest.php
@@ -8,7 +8,7 @@ class ListingTest extends CIUnitTestCase
 	/**
 	 * @var string
 	 */
-	private $input = '{"kind":"Listing", "data":{"children":[{"kind":"t3", "data":{"subreddit":"pythonforengineers","name":"t3_jw6u2r"}}]}, "after":"t3_abcdefg"}';
+	private $input = '{"kind":"Listing", "data":{"children":[{"kind":"t3", "data":{"subreddit":"pythonforengineers","name":"t3_jw6u2r"}}], "after":"t3_abcdefg"}}';
 
 	/**
 	 * @dataProvider queryParameterProvider


### PR DESCRIPTION
The `after` and `before` properties on `Listing` was preventing `__get()` from reading the correct values from `$data`. This PR removes the and cleans up meta related to their presence.